### PR TITLE
Create post request body validation middleware

### DIFF
--- a/api/middleware/topics/index.js
+++ b/api/middleware/topics/index.js
@@ -1,0 +1,87 @@
+const Profiles = require('../../profile/profileModel');
+
+// Validates values in Topic POST Request
+const validateTopicBody = async (req, res, next) => {
+  const {
+    created_by,
+    title,
+    frequency,
+    context_questions,
+    default_questions,
+  } = req.body;
+
+  const requestFrequencies = ['Daily', 'Weekly', 'Monthly'];
+  const responseTypes = ['Rating', 'String', 'Url', 'Boolean'];
+
+  if (!created_by || !title) {
+    return res
+      .status(400)
+      .json({ error: 'Topic must include created_by and title values' });
+  }
+
+  const topic_creator = await Profiles.findById(created_by);
+
+  if (!topic_creator) {
+    return res
+      .status(404)
+      .json({ error: 'Could not find user with id in database' });
+  }
+
+  if (!frequency) {
+    return res
+      .status(400)
+      .json({ error: 'Topic must include frequency value' });
+  } else if (!requestFrequencies.includes(frequency)) {
+    return res.status(400).json({
+      error: 'The frequency value must be Daily, Weekly, or Monthly',
+    });
+  }
+
+  if (!context_questions || !default_questions) {
+    return res.status(400).json({
+      error: 'Topic must include context_questions and default_questions',
+    });
+  }
+
+  if (!context_questions.length) {
+    return res.status(400).json({
+      error:
+        'Must have at least one context question in context_questions array',
+    });
+  }
+
+  context_questions.forEach((question) => {
+    if (!question) {
+      return res
+        .status(400)
+        .json({ error: 'Each context question must have content value' });
+    }
+  });
+
+  default_questions.forEach(({ content, response_type }) => {
+    if (!content || !response_type) {
+      return res.status(400).json({
+        error:
+          'Each context question must have content and response_type values',
+      });
+    }
+    if (!responseTypes.includes(response_type)) {
+      return res.status(400).json({
+        error:
+          'Default question response_type must be Rating, String, Url, or Boolean',
+      });
+    }
+  });
+
+  next();
+};
+
+// TODO
+const validateRequestBody = async (req, res, next) => {
+  return null;
+};
+
+module.exports = {
+  validateTopicBody,
+  validateRequestBody,
+};

--- a/api/middleware/topics/index.js
+++ b/api/middleware/topics/index.js
@@ -84,7 +84,7 @@ const validateRequestBody = async (req, res, next) => {
 
   const topic = await Topics.findById(topicId);
 
-  if (!topic) {
+  if (!topic.id) {
     return res.status(404).json({ error: 'Could not find topic with that id' });
   }
 

--- a/api/topics/topicRouter.js
+++ b/api/topics/topicRouter.js
@@ -1,5 +1,9 @@
 const express = require('express');
 // const authRequired = require('../middleware/authRequired');
+const {
+  validateTopicBody,
+  validateRequestBody,
+} = require('../middleware/topics/');
 const db = require('./topicModel');
 const router = express.Router();
 
@@ -124,7 +128,7 @@ const router = express.Router();
  */
 
 //posts
-router.post('/', (req, res) => {
+router.post('/', validateTopicBody, (req, res) => {
   const topicInfo = req.body;
 
   db.addTopic(topicInfo)
@@ -226,7 +230,7 @@ router.get('/:id', (req, res) => {
  *        $ref: '#/components/responses/UnauthorizedError'
  */
 
-router.post('/:topicId/request', (req, res) => {
+router.post('/:topicId/request', validateRequestBody, (req, res) => {
   const topicId = req.params.topicId;
   const { topic_questions, context_responses } = req.body;
   db.createIteration(topicId, topic_questions, context_responses)


### PR DESCRIPTION
Added middleware that confirms that the post requests in topics have the appropriate key/values that the API needs to work with

Type of change
[ ] Bug fix (non-breaking change which fixes an issue)
[x] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] This change requires a documentation update

Change Status
[ ] Complete, tested, ready to review and merge
[x] Complete, but not tested (may need new tests)
[ ] Incomplete/work-in-progress, PR is for discussion/feedback

Has This Been Tested?
[ ] Yes
[ ] What was tested?
[x] No

Checklist
[x] My code follows the style guidelines of this project
[ ] I have performed a self-review of my own code
[ ] My code has been reviewed and commented by at least two peers
[ ] I have commented my code, particularly in hard-to-understand areas
[ ] I have made corresponding changes to the documentation
[x] My changes generate no new warnings
[ ] I have added tests that prove my fix is effective or that my feature works
[ ] New and existing unit tests pass locally with my changes
[x] There are no merge conflicts