### PR TITLE
chore: Remove need to send up profile id for any post request

### DIFF
--- a/__tests__/routes/topics.test.js
+++ b/__tests__/routes/topics.test.js
@@ -3,16 +3,24 @@ const express = require('express');
 const Profiles = require('../../api/profile/profileModel');
 const topicDb = require('../../api/topics/topicModel');
 const topicRouter = require('../../api/topics/topicRouter');
+const authRequired = require('../../api/middleware/authRequired');
 const server = express();
 server.use(express.json());
 
 jest.mock('../../api/topics/topicModel');
 jest.mock('../../api/profile/profileModel');
 
+jest.mock('../../api/middleware/authRequired', () =>
+  jest.fn((req, res, next) => {
+    req.profile = { id: '1234' };
+    next();
+  })
+);
+
 describe('Topic router endpoints', () => {
   beforeAll(() => {
     // This is the module/route being tested
-    server.use('/topics', topicRouter);
+    server.use('/topics', authRequired, topicRouter);
     jest.clearAllMocks();
   });
 
@@ -55,7 +63,6 @@ describe('Topic router endpoints', () => {
   describe('POST /topics', () => {
     it('should return 201 when a topic is created', async () => {
       const topic = {
-        created_by: '00ulthapbErVUwVJy4x6',
         frequency: 'Monthly',
         title: 'Test005',
         context_questions: [

--- a/api/middleware/requests/index.js
+++ b/api/middleware/requests/index.js
@@ -2,7 +2,7 @@ const Requests = require('../../requests/requestModel');
 
 const validateRequestReplies = async (req, res, next) => {
   const { id } = req.params;
-  const { profile_id, replies } = req.body;
+  const { replies } = req.body;
 
   const request = await Requests.getRequestDetailed(id);
 
@@ -10,10 +10,6 @@ const validateRequestReplies = async (req, res, next) => {
     return res
       .status(404)
       .json({ error: 'Could not find a request with that id' });
-  }
-
-  if (!profile_id) {
-    return res.status(400).json({ error: 'Must include a profile id' });
   }
 
   if (!replies) {

--- a/api/middleware/topics/index.js
+++ b/api/middleware/topics/index.js
@@ -1,4 +1,3 @@
-const Profiles = require('../../profile/profileModel');
 const Topics = require('../../topics/topicModel');
 
 // Constant values
@@ -7,26 +6,10 @@ const responseTypes = ['Rating', 'String', 'Url', 'Boolean'];
 
 // Validates values in Topic POST Request
 const validateTopicBody = async (req, res, next) => {
-  const {
-    created_by,
-    title,
-    frequency,
-    context_questions,
-    default_questions,
-  } = req.body;
+  const { title, frequency, context_questions, default_questions } = req.body;
 
-  if (!created_by || !title) {
-    return res
-      .status(400)
-      .json({ error: 'Topic must include created_by and title values' });
-  }
-
-  const topic_creator = await Profiles.findById(created_by);
-
-  if (!topic_creator) {
-    return res
-      .status(404)
-      .json({ error: 'Could not find user with id in database' });
+  if (!title) {
+    return res.status(400).json({ error: 'Topic must include title value' });
   }
 
   if (!frequency) {

--- a/api/requests/requestRouter.js
+++ b/api/requests/requestRouter.js
@@ -83,7 +83,8 @@ const { validateRequestReplies } = require('../middleware/requests');
 
 router.post('/:id', validateRequestReplies, (req, res) => {
   const { id } = req.params;
-  const { profile_id, replies } = req.body;
+  const { replies } = req.body;
+  const profile_id = req.profile.id;
 
   Requests.addRequestReplies(id, profile_id, replies).then((requestInfo) => {
     if (requestInfo) {

--- a/api/requests/requestRouter.js
+++ b/api/requests/requestRouter.js
@@ -9,7 +9,6 @@ const { validateRequestReplies } = require('../middleware/requests');
  *    postReplies:
  *      type: object
  *      required:
- *        - profile_id
  *        - replies
  *      properties:
  *        profile_id:
@@ -24,7 +23,6 @@ const { validateRequestReplies } = require('../middleware/requests');
  *              content:
  *                type: string
  *      example:
- *        profile_id: '00uhjfrwdWAQvD8JV4x6'
  *        replies: [{question_id: 1, content: "String"}, {question_id: 2, content: "String"}, {question_id: 3, content: "String"}]
  */
 

--- a/api/topics/topicRouter.js
+++ b/api/topics/topicRouter.js
@@ -129,8 +129,9 @@ const router = express.Router();
 //posts
 router.post('/', validateTopicBody, (req, res) => {
   const topicInfo = req.body;
+  const created_by = req.profile.id;
 
-  Topics.addTopic(topicInfo)
+  Topics.addTopic({ ...topicInfo, created_by })
     .then((topic) => {
       console.log(topic);
       res.status(201).json(topic);
@@ -265,7 +266,7 @@ router.get('/:id', (req, res) => {
 
 router.post('/:id/join', (req, res) => {
   const id = req.params.id;
-  const profileId = req.body.profile_id;
+  const profileId = req.profile.id;
   Topics.addMemberToTopic(id, profileId)
     .then(() => {
       res

--- a/api/topics/topicRouter.js
+++ b/api/topics/topicRouter.js
@@ -108,14 +108,13 @@ const router = express.Router();
  *      - topic
  *    responses:
  *      201:
- *        description: Needed information to post a topic, Returns topic Information. By sending up - "created_by", "title", "frequency", "context_questions", "default_questions", a new topic will be formed! ----------- FREQUENCY* HAS TO BE "Daily", "Weekly" or "Monthly" ------------- RESPONSE_TYPE* HAS TO BE "Rating", "String", "Url" or "Boolean" Correct spelling and casing.
+ *        description: Needed information to post a topic, Returns topic Information. By sending up "title", "frequency", "context_questions", "default_questions", a new topic will be formed! ----------- FREQUENCY* HAS TO BE "Daily", "Weekly" or "Monthly" ------------- RESPONSE_TYPE* HAS TO BE "Rating", "String", "Url" or "Boolean" Correct spelling and casing.
  *        content:
  *          application/json:
  *            schema:
  *              type: object
  *              example:
- *                - created_by: '00uhjfrwdWAQvD8JV4x6'
- *                  title: "Topic Name"
+ *                - title: "Topic Name"
  *                  frequency: "Daily"
  *                  context_questions: ["Question 1", "Question 2", "Question 3"]
  *                  default_questions: [{content: "Question 1", response_type: "String"}, {content: "Question 2", response_type: "String"}, {content: "Question 3", response_type: "String"}]
@@ -241,14 +240,6 @@ router.get('/:id', (req, res) => {
  *      - topic
  *    parameters:
  *      - $ref: '#/components/parameters/topicId'
- *    requestBody:
- *      description: Data to send up. Must include all the data below to reply to join a topic.
- *      content:
- *        application/json:
- *          schema:
- *              type: object
- *              example:
- *                  - "profile_id": "00ulthapbErVUwVJy4x6"
  *    responses:
  *      200:
  *        description: the response from a successful post to the endpoint.


### PR DESCRIPTION
Made small changes to the post endpoints to grab the profile id from the authRequired middleware instead of the request body